### PR TITLE
Add basic Flutter entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+.flutter-plugins
+generated_plugin_registrant.dart
+
+# IDEs
+.idea/
+*.iml
+
+# Other
+.env

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Revity',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const HomeScreen(),
+    );
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+      ),
+      body: const Center(
+        child: Text('Welcome to Revity!'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: revity
+description: A simple Flutter project.
+version: 1.0.0+1
+publish_to: 'none'
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- set up flutter project stubs
- add HomeScreen and Material theme in main.dart
- add minimal pubspec
- ignore build artifacts

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ccf4210748331bb0568d74573035d